### PR TITLE
Add The Nonlinear Library to project list and correct a typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Before you submit a pull request, check that it meets these guidelines:
   awesome_bot README.md
   ```
 3. Keep the contents sorted alphabetically
-4. Update the table of contents if necesseray
+4. Update the table of contents if necessary
 
 Thank you for your suggestions!
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An unofficial list of personal and open source projects that are relevant to EA 
   - [Open Source Projects](#open-source-projects)
     - [AI Safety](#ai-safety)
     - [General](#general)
+    - [Multiple Cause Areas](#multiple-cause-areas)
   - [Other Awesome Lists](#other-awesome-lists)
   - [Contribute](#contribute)
   - [Credits](#credits)
@@ -39,6 +40,10 @@ Recommended by EA Software Engineers
 ##### General
 
 - [Advice for getting started in Open Source](https://gist.github.com/NicoleJaneway/45069ea3ec808c5507d0e69282976457)
+
+##### Multiple Cause Areas
+
+- [The Nonlinear Library](https://github.com/Nonlinear-EA/The-Nonlinear-Library) - automatically turns posts from the EA Forum, Alignment Forum, and LessWrong into a podcast you can listen to. [Read more here](https://forum.effectivealtruism.org/posts/JTZTBienqWEAjGDRv/listen-to-more-ea-content-with-the-nonlinear-library).
 
 ## Other Awesome Lists
 


### PR DESCRIPTION
Add The Nonlinear Library to Multiple Cause Areas

The Nonlinear Library automatically turns posts from the EA Forum, Alignment Forum, and LessWrong into a podcast you can listen to.
The Nonlinear Library fits under Multiple Cause Areas because there are Nonlinear Library podcasts under the topics of animal advocacy, AI safety, and animal welfare, amongst other topics / cause areas.

- [ X] Table of contents has been updated (if needed)
- [X ] Contents have been sorted alphabetically
